### PR TITLE
Feature/mph 168

### DIFF
--- a/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
@@ -29,8 +29,8 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.model.InputLocation;
-import org.apache.maven.model.Model;
 import org.apache.maven.model.InputSource;
+import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.apache.maven.model.io.xpp3.MavenXpp3WriterExOldSupport;
 import org.apache.maven.plugin.MojoExecution;
@@ -55,7 +55,7 @@ import org.codehaus.plexus.util.xml.pull.XmlSerializer;
  */
 @Mojo( name = "effective-pom", aggregator = true )
 public class EffectivePomMojo
-    extends AbstractEffectiveMojo
+        extends AbstractEffectiveMojo
 {
     // ----------------------------------------------------------------------
     // Mojo parameters
@@ -95,7 +95,7 @@ public class EffectivePomMojo
 
     /**
      * Output POM input location as comments.
-     * 
+     *
      * @since 3.2.0
      */
     @Parameter( property = "verbose", defaultValue = "false" )
@@ -114,9 +114,11 @@ public class EffectivePomMojo
     // Public methods
     // ----------------------------------------------------------------------
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public void execute()
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         if ( StringUtils.isNotEmpty( artifact ) )
         {
@@ -126,10 +128,10 @@ public class EffectivePomMojo
 
         StringWriter w = new StringWriter();
         String encoding = output != null ? project.getModel().getModelEncoding()
-                                : System.getProperty( "file.encoding" );
+                : System.getProperty( "file.encoding" );
         XMLWriter writer =
-            new PrettyPrintXMLWriter( w, StringUtils.repeat( " ", XmlWriterUtil.DEFAULT_INDENTATION_SIZE ),
-                                      encoding, null );
+                new PrettyPrintXMLWriter( w, StringUtils.repeat( " ", XmlWriterUtil.DEFAULT_INDENTATION_SIZE ),
+                        encoding, null );
 
         writeHeader( writer );
 
@@ -207,11 +209,11 @@ public class EffectivePomMojo
      * Method for writing the effective pom informations of the current build.
      *
      * @param project the project of the current build, not null.
-     * @param writer the XML writer , not null, not null.
+     * @param writer  the XML writer , not null, not null.
      * @throws MojoExecutionException if any
      */
     private void writeEffectivePom( MavenProject project, XMLWriter writer )
-        throws MojoExecutionException
+            throws MojoExecutionException
     {
         Model pom = project.getModel();
         cleanModel( pom );
@@ -222,7 +224,7 @@ public class EffectivePomMojo
             if ( verbose )
             {
                 // try to use Maven core-provided xpp3 extended writer (available since Maven 3.6.1)
-                if ( ! writeMavenXpp3WriterEx( sWriter, pom ) )
+                if ( !writeMavenXpp3WriterEx( sWriter, pom ) )
                 {
                     // xpp3 extended writer not provided by Maven core, use local code
                     new EffectiveWriterExOldSupport().write( sWriter, pom );
@@ -261,11 +263,11 @@ public class EffectivePomMojo
     private void warnWriteMavenXpp3WriterEx( Throwable t )
     {
         getLog().warn( "Unexpected exception while running Maven Model Extended Writer, "
-            + "falling back to old internal implementation.", t );
+                + "falling back to old internal implementation.", t );
     }
 
     private boolean writeMavenXpp3WriterEx( Writer writer, Model model )
-        throws IOException
+            throws IOException
     {
         try
         {
@@ -273,7 +275,7 @@ public class EffectivePomMojo
             Object mavenXpp3WriterEx = mavenXpp3WriterExClass.getDeclaredConstructor().newInstance();
 
             Method setStringFormatter =
-                mavenXpp3WriterExClass.getMethod( "setStringFormatter", InputLocation.StringFormatter.class );
+                    mavenXpp3WriterExClass.getMethod( "setStringFormatter", InputLocation.StringFormatter.class );
             setStringFormatter.invoke( mavenXpp3WriterEx, new InputLocationStringFormatter() );
 
             Method write = mavenXpp3WriterExClass.getMethod( "write", Writer.class, Model.class );
@@ -321,7 +323,7 @@ public class EffectivePomMojo
     }
 
     private static class InputLocationStringFormatter
-        extends InputLocation.StringFormatter
+            extends InputLocation.StringFormatter
     {
 
         public String toString( InputLocation location )
@@ -335,7 +337,7 @@ public class EffectivePomMojo
      * Xpp3 extended writer extension to improve default InputSource display
      */
     private static class EffectiveWriterExOldSupport
-        extends MavenXpp3WriterExOldSupport
+            extends MavenXpp3WriterExOldSupport
     {
 
         @Override
@@ -346,7 +348,7 @@ public class EffectivePomMojo
 
         @Override
         protected void writeXpp3DomToSerializer( Xpp3Dom dom, XmlSerializer serializer )
-            throws IOException
+                throws IOException
         {
             // default method uses Xpp3Dom input location tracking, not available in older Maven versions
             // use old Xpp3Dom serialization, without input location tracking

--- a/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
@@ -128,63 +128,73 @@ public class EffectivePomMojo
         }
         if ( individual )
         {
-            String encoding = project.getModel().getModelEncoding();
-            if ( shouldWriteAllEffectivePOMsInReactor() )
+            generateIndividualEffectivePom();
+        }
+        else
+        {
+            generateSingleEffectivePom();
+        }
+    }
+
+    private void generateSingleEffectivePom() throws MojoExecutionException
+    {
+        StringWriter w = new StringWriter();
+        String encoding = output != null ? project.getModel().getModelEncoding()
+                : System.getProperty( "file.encoding" );
+        XMLWriter writer =
+                getPrettyPrintXMLWriterForEffectivePom( w, encoding );
+
+        writeHeader( writer );
+        if ( shouldWriteAllEffectivePOMsInReactor() )
+        {
+            // outer root element
+            writer.startElement( "projects" );
+            for ( MavenProject subProject : projects )
             {
-                // outer root element
-                for ( MavenProject subProject : projects )
-                {
-                    StringWriter w = new StringWriter();
-                    XMLWriter writer =
-                            getPrettyPrintXMLWriterForEffectivePom( w, encoding );
-                    writeHeader( writer );
-                    writeEffectivePom( subProject, writer );
-                    String effectivePom = prettyFormat( w.toString(), encoding, false );
-                    effectivePom = prettyFormatVerbose( effectivePom );
-                    File effectiveOutput = new File( subProject.getBuild().getDirectory() + "/effective.pom.xml" );
-                    reportEffectivePom( effectivePom, effectiveOutput );
-                }
+                writeEffectivePom( subProject, writer );
             }
-            else
+            writer.endElement();
+        }
+        else
+        {
+            writeEffectivePom( project, writer );
+        }
+
+        String effectivePom = prettyFormat( w.toString(), encoding, false );
+        effectivePom = prettyFormatVerbose( effectivePom );
+        reportEffectivePom( effectivePom, output );
+    }
+
+    private void generateIndividualEffectivePom() throws MojoExecutionException
+    {
+        String encoding = project.getModel().getModelEncoding();
+        if ( shouldWriteAllEffectivePOMsInReactor() )
+        {
+            // outer root element
+            for ( MavenProject subProject : projects )
             {
                 StringWriter w = new StringWriter();
                 XMLWriter writer =
                         getPrettyPrintXMLWriterForEffectivePom( w, encoding );
                 writeHeader( writer );
-                writeEffectivePom( project, writer );
+                writeEffectivePom( subProject, writer );
                 String effectivePom = prettyFormat( w.toString(), encoding, false );
                 effectivePom = prettyFormatVerbose( effectivePom );
-                File effectiveOutput = new File( project.getBuild().getDirectory() + "/effective.pom.xml" );
+                File effectiveOutput = new File( subProject.getBuild().getDirectory() + "/effective.pom.xml" );
                 reportEffectivePom( effectivePom, effectiveOutput );
             }
         }
         else
         {
             StringWriter w = new StringWriter();
-            String encoding = output != null ? project.getModel().getModelEncoding()
-                    : System.getProperty( "file.encoding" );
             XMLWriter writer =
                     getPrettyPrintXMLWriterForEffectivePom( w, encoding );
-
             writeHeader( writer );
-            if ( shouldWriteAllEffectivePOMsInReactor() )
-            {
-                // outer root element
-                writer.startElement( "projects" );
-                for ( MavenProject subProject : projects )
-                {
-                    writeEffectivePom( subProject, writer );
-                }
-                writer.endElement();
-            }
-            else
-            {
-                writeEffectivePom( project, writer );
-            }
-
+            writeEffectivePom( project, writer );
             String effectivePom = prettyFormat( w.toString(), encoding, false );
             effectivePom = prettyFormatVerbose( effectivePom );
-            reportEffectivePom( effectivePom, output );
+            File effectiveOutput = new File( project.getBuild().getDirectory() + "/effective.pom.xml" );
+            reportEffectivePom( effectivePom, effectiveOutput );
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
@@ -101,6 +101,15 @@ public class EffectivePomMojo
     @Parameter( property = "verbose", defaultValue = "false" )
     private boolean verbose = false;
 
+    /**
+     * Generate an effective pom for each module individually and
+     * save it in ${project.build.outputDirectory}/effective.pom.xml.
+     *
+     * @since 3.3.0
+     */
+    @Parameter( property = "individual", defaultValue = "false" )
+    private boolean individual = false;
+
     // ----------------------------------------------------------------------
     // Public methods
     // ----------------------------------------------------------------------


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MPH) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MPH-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MPH-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf). **I'm in the process.**

---

This PR closes https://issues.apache.org/jira/browse/MPH-168.

I have chosen to solve this issue using a new parameter `individual`. I chose this name because you are generating an effective POM for each project/module individually. It is already possible to generate an effective POM across for each project/module, but it will put it in a single result/file. Please, advice on this naming if you like it or what it should be changed to.

I have not yet built the support of specifying `output` in combination with `individual`. For now, it will always output the effective POM to `${projectDirectory}/target/effective.pom.xml`. In the issue it mentions setting the `output` to `${project.build.directory}/effective-pom.xml`, but I'm not sure how to transform the variable part in it per project.

IMO the code does not look very clean, I think some of it could be refactored, but I'm not sure in what way.