### PR TITLE
Allow defining complex expression like in interactive mode

### DIFF
--- a/src/main/java/org/apache/maven/plugins/help/EvaluateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EvaluateMojo.java
@@ -113,7 +113,7 @@ public class EvaluateMojo extends AbstractHelpMojo {
     private String artifact;
 
     /**
-     * An expression to evaluate instead of prompting. Note that this <i>must not</i> include the surrounding ${...}.
+     * An expression to evaluate instead of prompting. Note that this <i>may not</i> include the surrounding ${...}.
      */
     @Parameter(property = "expression")
     private String expression;
@@ -200,7 +200,10 @@ public class EvaluateMojo extends AbstractHelpMojo {
                 }
             }
         } else {
-            handleResponse("${" + expression + "}", output);
+            if (!expression.contains("${")) {
+                expression = "${" + expression + "}";
+            }
+            handleResponse(expression, output);
         }
     }
 


### PR DESCRIPTION
Overlapping parameter expression for goal `help:evaluate` by default:
`handleResponse("${" + expression + "}", output);`

 limits usage for more complex expressions, e.g.
`mvn help:evaluate -Dexpression='project_version=${project.version}'`

which currently fails with message:
`null object or invalid expression`

Skipping the overlapping when an expression already contains string '${' removes this limitation and allows to define expression in the same way as in the interactive mode:
`echo 'project_version=${project.version}'|mvn help:evaluate`

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)