### PR TITLE
Fix help #367 :describe showing "Not defined" for all lifecycle phases with Maven 3.10.0

### DIFF
--- a/src/main/java/org/apache/maven/plugins/help/DescribeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/DescribeMojo.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -39,6 +40,7 @@ import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.Lifecycle;
 import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
 import org.apache.maven.lifecycle.mapping.LifecycleMapping;
+import org.apache.maven.lifecycle.mapping.LifecyclePhase;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.plugin.MavenPluginManager;
@@ -650,15 +652,16 @@ public class DescribeMojo extends AbstractHelpMojo {
                 throw new MojoExecutionException("The given phase '" + cmd + "' is an unknown phase.");
             }
 
-            // FIXME don't use a deprecated methods
-            Map<String, String> defaultLifecyclePhases = lifecycleMappings
-                    .get(project.getPackaging())
-                    .getLifecycles()
-                    .get("default")
-                    .getPhases();
+            LifecycleMapping packagingMapping = lifecycleMappings.get(project.getPackaging());
+            org.apache.maven.lifecycle.mapping.Lifecycle packagingLifecycle =
+                    packagingMapping != null ? packagingMapping.getLifecycles().get(lifecycle.getId()) : null;
+            Map<String, LifecyclePhase> rawPhases =
+                    packagingLifecycle != null ? packagingLifecycle.getLifecyclePhases() : null;
+            Map<String, LifecyclePhase> packagingPhases = rawPhases != null ? rawPhases : Collections.emptyMap();
             List<String> phases = lifecycle.getPhases();
 
-            if (lifecycle.getDefaultPhases() == null) {
+            Map<String, LifecyclePhase> builtinPhases = lifecycle.getDefaultLifecyclePhases();
+            if (builtinPhases == null || builtinPhases.isEmpty()) {
                 descriptionBuffer.append("'").append(cmd);
                 descriptionBuffer
                         .append("' is a phase corresponding to this plugin:")
@@ -667,8 +670,8 @@ public class DescribeMojo extends AbstractHelpMojo {
                     if (!key.equals(cmd)) {
                         continue;
                     }
-                    if (defaultLifecyclePhases.get(key) != null) {
-                        descriptionBuffer.append(defaultLifecyclePhases.get(key));
+                    if (packagingPhases.get(key) != null) {
+                        descriptionBuffer.append(packagingPhases.get(key));
                         descriptionBuffer.append(LS);
                     }
                 }
@@ -680,7 +683,8 @@ public class DescribeMojo extends AbstractHelpMojo {
                 descriptionBuffer.append(LS);
                 for (String key : phases) {
                     descriptionBuffer.append("* ").append(key).append(": ");
-                    String value = defaultLifecyclePhases.get(key);
+                    LifecyclePhase phase = packagingPhases.get(key);
+                    String value = phase != null ? phase.toString() : null;
                     if (value != null && !value.isEmpty()) {
                         for (StringTokenizer tok = new StringTokenizer(value, ","); tok.hasMoreTokens(); ) {
                             descriptionBuffer.append(tok.nextToken().trim());
@@ -703,10 +707,9 @@ public class DescribeMojo extends AbstractHelpMojo {
 
                 for (String key : phases) {
                     descriptionBuffer.append("* ").append(key).append(": ");
-                    if (lifecycle.getDefaultPhases().get(key) != null) {
-                        descriptionBuffer
-                                .append(lifecycle.getDefaultPhases().get(key))
-                                .append(LS);
+                    LifecyclePhase phase = builtinPhases.get(key);
+                    if (phase != null) {
+                        descriptionBuffer.append(phase).append(LS);
                     } else {
                         descriptionBuffer.append(NOT_DEFINED).append(LS);
                     }

--- a/src/test/java/org/apache/maven/plugins/help/DescribeMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/help/DescribeMojoTest.java
@@ -21,12 +21,21 @@ package org.apache.maven.plugins.help;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.Lifecycle;
 import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
+import org.apache.maven.lifecycle.mapping.LifecycleMapping;
+import org.apache.maven.lifecycle.mapping.LifecyclePhase;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MavenPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -40,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -389,5 +399,122 @@ class DescribeMojoTest {
         Method parsePluginLookupInfo = DescribeMojo.class.getDeclaredMethod("parsePluginLookupInfo");
         parsePluginLookupInfo.setAccessible(true);
         return parsePluginLookupInfo;
+    }
+
+    /**
+     * Regression test for Maven 3.10.0 behavior where {@code Lifecycle.getDefaultLifecyclePhases()}
+     * returns an empty map (not null) for the "default" lifecycle.
+     * The mojo must fall through to the packaging-specific lifecycle mapping in that case.
+     */
+    @Test
+    void testDescribeCommandPackagingSpecificPhaseShowsBindings() throws Exception {
+        // default lifecycle: built-in phases are empty (3.10.0 behavior)
+        Lifecycle lifecycle = mock(Lifecycle.class);
+        when(lifecycle.getId()).thenReturn("default");
+        when(lifecycle.getPhases()).thenReturn(Arrays.asList("validate", "compile", "test", "package"));
+        when(lifecycle.getDefaultLifecyclePhases()).thenReturn(Collections.emptyMap());
+
+        Map<String, Lifecycle> phaseMap = new HashMap<>();
+        for (String p : Arrays.asList("validate", "compile", "test", "package")) {
+            phaseMap.put(p, lifecycle);
+        }
+        DefaultLifecycles defaultLifecycles = mock(DefaultLifecycles.class);
+        when(defaultLifecycles.getPhaseToLifecycleMap()).thenReturn(phaseMap);
+
+        // packaging-specific bindings: only "compile" phase is bound
+        Map<String, LifecyclePhase> lifecyclePhases = new LinkedHashMap<>();
+        lifecyclePhases.put(
+                "compile", new LifecyclePhase("org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile"));
+        org.apache.maven.lifecycle.mapping.Lifecycle mappingLifecycle =
+                new org.apache.maven.lifecycle.mapping.Lifecycle();
+        mappingLifecycle.setLifecyclePhases(lifecyclePhases);
+
+        LifecycleMapping lifecycleMapping = mock(LifecycleMapping.class);
+        when(lifecycleMapping.getLifecycles()).thenReturn(Collections.singletonMap("default", mappingLifecycle));
+
+        MavenProject project = mock(MavenProject.class);
+        when(project.getPackaging()).thenReturn("jar");
+
+        DescribeMojo mojo = new DescribeMojo(
+                null, null, null, null, null, defaultLifecycles, Collections.singletonMap("jar", lifecycleMapping));
+        setFieldWithReflection(mojo, "cmd", "compile");
+        setParentFieldWithReflection(mojo, "project", project);
+
+        StringBuilder sb = new StringBuilder();
+        Method describeCommand = DescribeMojo.class.getDeclaredMethod("describeCommand", StringBuilder.class);
+        describeCommand.setAccessible(true);
+        boolean result = (boolean) describeCommand.invoke(mojo, sb);
+
+        String output = sb.toString();
+        assertFalse(result);
+        assertTrue(output.contains("maven-compiler-plugin"), "Should show compiler plugin: " + output);
+        assertFalse(output.contains("* compile: Not defined"), "compile should not be 'Not defined': " + output);
+        assertTrue(output.contains("* validate: Not defined"), "validate has no binding: " + output);
+        assertTrue(output.contains("It is a part of the lifecycle for the POM packaging 'jar'"), output);
+    }
+
+    /**
+     * Built-in lifecycle (e.g. "clean") has non-empty {@code getDefaultLifecyclePhases()} —
+     * the mojo should use those directly without consulting lifecycle mappings.
+     */
+    @Test
+    void testDescribeCommandBuiltinLifecyclePhaseShowsBindings() throws Exception {
+        Map<String, LifecyclePhase> builtinPhases = new LinkedHashMap<>();
+        builtinPhases.put("pre-clean", null);
+        builtinPhases.put("clean", new LifecyclePhase("org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean"));
+        builtinPhases.put("post-clean", null);
+
+        Lifecycle lifecycle = mock(Lifecycle.class);
+        when(lifecycle.getId()).thenReturn("clean");
+        when(lifecycle.getPhases()).thenReturn(Arrays.asList("pre-clean", "clean", "post-clean"));
+        when(lifecycle.getDefaultLifecyclePhases()).thenReturn(builtinPhases);
+
+        Map<String, Lifecycle> phaseMap = new HashMap<>();
+        for (String p : Arrays.asList("pre-clean", "clean", "post-clean")) {
+            phaseMap.put(p, lifecycle);
+        }
+        DefaultLifecycles defaultLifecycles = mock(DefaultLifecycles.class);
+        when(defaultLifecycles.getPhaseToLifecycleMap()).thenReturn(phaseMap);
+
+        MavenProject project = mock(MavenProject.class);
+        when(project.getPackaging()).thenReturn("jar");
+
+        DescribeMojo mojo = new DescribeMojo(null, null, null, null, null, defaultLifecycles, Collections.emptyMap());
+        setFieldWithReflection(mojo, "cmd", "clean");
+        setParentFieldWithReflection(mojo, "project", project);
+
+        StringBuilder sb = new StringBuilder();
+        Method describeCommand = DescribeMojo.class.getDeclaredMethod("describeCommand", StringBuilder.class);
+        describeCommand.setAccessible(true);
+        boolean result = (boolean) describeCommand.invoke(mojo, sb);
+
+        String output = sb.toString();
+        assertFalse(result);
+        assertTrue(output.contains("'clean' is a phase within the 'clean' lifecycle"), output);
+        assertTrue(output.contains("maven-clean-plugin"), output);
+        assertTrue(output.contains("* pre-clean: Not defined"), output);
+        assertTrue(output.contains("* post-clean: Not defined"), output);
+    }
+
+    @Test
+    void testDescribeCommandUnknownPhaseThrows() throws Exception {
+        DefaultLifecycles defaultLifecycles = mock(DefaultLifecycles.class);
+        when(defaultLifecycles.getPhaseToLifecycleMap()).thenReturn(Collections.emptyMap());
+
+        DescribeMojo mojo = new DescribeMojo(null, null, null, null, null, defaultLifecycles, Collections.emptyMap());
+        setFieldWithReflection(mojo, "cmd", "nonexistent-phase");
+        setParentFieldWithReflection(mojo, "project", mock(MavenProject.class));
+
+        Method describeCommand = DescribeMojo.class.getDeclaredMethod("describeCommand", StringBuilder.class);
+        describeCommand.setAccessible(true);
+        try {
+            describeCommand.invoke(mojo, new StringBuilder());
+            fail("Expected MojoExecutionException");
+        } catch (InvocationTargetException e) {
+            assertTrue(
+                    e.getTargetException() instanceof MojoExecutionException,
+                    "Expected MojoExecutionException, got: " + e.getTargetException());
+            assertTrue(e.getTargetException().getMessage().contains("nonexistent-phase"));
+        }
     }
 }


### PR DESCRIPTION

Following this checklist to help us incorporate your
contribution quickly and easily:

  ## Problem

  Since Maven 3.10.0, `mvn help:describe -Dcmd=<phase>` shows `Not defined`
  for every phase in the lifecycle, regardless of the actual plugin bindings.

  Example with `maven-plugin` packaging:
  - compile: Not defined
  - test: Not defined
  - deploy: Not defined

  ## Root Cause

  In Maven 3.10.0 (`apache/maven#11916`), `Lifecycle.getDefaultLifecyclePhases()`
  now returns an **empty `Map`** (not `null`) for the `default` lifecycle, because
  packaging-specific bindings are not part of the lifecycle definition itself.

  `DescribeMojo` used the old `null` check to decide which path to take:

  ```java
  // 3.9.x: returns null for default lifecycle → correct path taken
  // 3.10.0: returns empty Map → falls into else branch → all phases "Not defined"
  if (lifecycle.getDefaultPhases() == null) {
      // use packaging-specific lifecycleMappings ← correct
  } else {
      // use lifecycle.getDefaultPhases() ← empty map in 3.10.0
  }
  ```
  Fix
```java
  - Replace getDefaultPhases() == null with
  getDefaultLifecyclePhases() == null || getDefaultLifecyclePhases().isEmpty()
  - Replace getDefaultPhases() == null with
  getDefaultLifecyclePhases() == null || getDefaultLifecyclePhases().isEmpty()
  - Replace deprecated getDefaultPhases() / getPhases() with
  getDefaultLifecyclePhases() / getLifecyclePhases() throughout
  - Use lifecycle.getId() instead of hardcoded "default" when looking up
  packaging-specific bindings
  - Add null guard for getLifecyclePhases() which can return null if the
  lifecycle mapping was constructed without setting phases
```
  Testing

  Three unit tests added to DescribeMojoTest:
```java
  - testDescribeCommandPackagingSpecificPhaseShowsBindings — regression test:
  verifies correct plugin bindings shown when builtinPhases is empty (3.10.0 behavior)
  - testDescribeCommandBuiltinLifecyclePhaseShowsBindings — verifies clean/site
  lifecycles still use their built-in bindings directly
  - testDescribeCommandUnknownPhaseThrows — verifies MojoExecutionException
  thrown for unknown phase names
```
  Fixes #367
  Related: apache/maven#12181

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
