### PR TITLE
Fix effective-pom_properties IT for Maven 4 compatibility

### DIFF
--- a/src/it/projects/effective-pom_properties/invoker.properties
+++ b/src/it/projects/effective-pom_properties/invoker.properties
@@ -16,3 +16,9 @@
 # under the License.
 
 invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:effective-pom
+
+# verify.groovy asserts that user properties override pom properties on Maven 4,
+# expecting maven.compiler.source/target = 8 in the rendered effective POM.
+# Pass them as -D user properties so the override actually happens.
+invoker.systemProperties.maven.compiler.source = 8
+invoker.systemProperties.maven.compiler.target = 8


### PR DESCRIPTION
## Summary

The `effective-pom_properties` integration test is the single IT failing under Maven 4.0.0-rc-5 on master, which leaves PR #363 ("enable build with Maven 4") with a red CI matrix. This PR fixes the IT fixture so the rc-5 matrix turns green.

## Root cause

`verify.groovy` was updated in #344 (merged 2025-10-31) to branch on `mavenVersion.startsWith('4.')` and assert that `maven.compiler.source/target = 8` appear in the rendered effective POM — testing that user properties override pom properties on Maven 4.

The change updated *only* `verify.groovy`. The companion `invoker.properties` was never extended to actually pass `-Dmaven.compiler.source=8 -Dmaven.compiler.target=8` (or the `invoker.systemProperties.*` form) into the invoked Maven build. So under Maven 4 the invocation didn't define those user properties at all, the rendered effective POM legitimately showed the pom-property values (`1.6`/`1.6`), and the new Maven-4 assertion fired unconditionally.

The bug is entirely in the IT fixture; the production `MavenHelpPlugin` is unaffected.

## Fix

Three lines added to `src/it/projects/effective-pom_properties/invoker.properties`:

```properties
invoker.systemProperties.maven.compiler.source = 8
invoker.systemProperties.maven.compiler.target = 8
```

## Verification

- `mvn -P run-its -Dinvoker.test='effective-pom_properties' verify` against Maven `4.0.0-rc-5` (sdkman, JDK 17.0.18 Temurin / macOS aarch64): **Passed: 1, Failed: 0, Errors: 0, Skipped: 0**.
- Without the fix the same invocation reproduces the failure that PR #363's CI shows.

## Context

- Unblocks #363 (CI matrix flip to `maven4-enabled: true`).
- Part of the broader Maven 4 compatibility work tracked on the [Maven 4.0.0 GA checklist](https://cwiki.apache.org/confluence/display/MAVEN/Maven+4.0.0+GA+checklist).
- No production code change; no POM/dependency bump.
