### PR TITLE
revert broken IT updates from #344

### DIFF
--- a/src/it/projects/active-profiles_multimodule/verify.groovy
+++ b/src/it/projects/active-profiles_multimodule/verify.groovy
@@ -20,15 +20,7 @@
 def buildLog = new File( basedir, 'build.log' ); 
 assert buildLog.exists()
 
-if (mavenVersion.startsWith( '4.' )) {
-    assert 1 == buildLog.text.count(' - mph79 (source: org.apache.maven.its.help:active-profiles_multimodule:pom:1.0-SNAPSHOT)')
-    assert 1 == buildLog.text.count(' - mph79 (source: org.apache.maven.its.help:active-profiles_multimodule-module:jar:1.0-SNAPSHOT)')
-    assert 1 == buildLog.text.count('- mph79-child (source: org.apache.maven.its.help:active-profiles_multimodule-module:jar:1.0-SNAPSHOT)')
-
-} else {
-    assert 2 == buildLog.text.count(' - mph79 (source: org.apache.maven.its.help:active-profiles_multimodule:1.0-SNAPSHOT)')
-    assert 1 == buildLog.text.count(' - mph79-child (source: org.apache.maven.its.help:active-profiles_multimodule-module:1.0-SNAPSHOT)')
-}
-
-assert 0 == buildLog.text.count(' - mph79-child-inactive')
-assert 2 == buildLog.text.count(' - it-repo (source: external)')
+assert 2 == buildLog.text.count( ' - mph79 (source: org.apache.maven.its.help:active-profiles_multimodule:1.0-SNAPSHOT)' )
+assert 1 == buildLog.text.count( ' - mph79-child (source: org.apache.maven.its.help:active-profiles_multimodule-module:1.0-SNAPSHOT)' )
+assert 0 == buildLog.text.count( ' - mph79-child-inactive' )
+assert 2 == buildLog.text.count( ' - it-repo (source: external)' )

--- a/src/it/projects/effective-pom_properties/verify.groovy
+++ b/src/it/projects/effective-pom_properties/verify.groovy
@@ -16,22 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-def buildLog = new File(basedir, 'build.log'); 
+def buildLog = new File(basedir, 'build.log');
 assert buildLog.exists()
 
 def LS = System.getProperty("line.separator")
 if (mavenVersion.startsWith('4.')) {
-    // we have defined properties maven.compiler.source/target to 8 as user properties for execution
-    // Maven 4 take precedence over the pom properties
-    // also order of properties is changed in Maven 4
+    // with Maven 4, order of properties is reversed from original pom.xml
     assert buildLog.text.find(
             '(?s)' +
                     '  <properties>' + LS +
-                    '    <maven\\.compiler\\.target>8</maven\\.compiler\\.target>' + LS +
-                    '    <maven\\.compiler\\.source>8</maven\\.compiler\\.source>' + LS +
+                    '    <maven\\.compiler\\.target>1\\.6</maven\\.compiler\\.target>' + LS +
+                    '    <maven\\.compiler\\.source>1\\.6</maven\\.compiler\\.source>' + LS +
                     '.*' +
                     '  </properties>') != null
-
 } else {
     assert buildLog.text.find(
             '(?s)' +


### PR DESCRIPTION
#344 contains untested Maven 4 cases in CI, in addition to expected parent upgrade

after working on #363 , clearly we need to revert 2 modifications, as they break ITs that work perfectly with Maven 4.0.0 RC 4, RC 5 and SNAPSHOT