### PR TITLE
Remove raw types from SortedProperties.keySet()

### DIFF
--- a/src/main/java/org/apache/maven/plugins/help/AbstractEffectiveMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/AbstractEffectiveMojo.java
@@ -140,11 +140,13 @@ public abstract class AbstractEffectiveMojo extends AbstractHelpMojo {
         static final long serialVersionUID = -8985316072702233744L;
 
         /** {@inheritDoc} */
-        @SuppressWarnings({"rawtypes", "unchecked"})
         @Override
         public Set<Object> keySet() {
             Set<Object> keynames = super.keySet();
-            List list = new ArrayList(keynames);
+            List<String> list = new ArrayList<>();
+            for (Object key : keynames) {
+                list.add((String) key);
+            }
             Collections.sort(list);
 
             return new LinkedHashSet<>(list);


### PR DESCRIPTION
Fixes #392

Replace the raw `List` / `ArrayList` (masked by `@SuppressWarnings({rawtypes, unchecked})`) with a properly parameterized `List<String>` populated via an explicit typed loop. `Collections.sort` is now also type-safe.