### PR TITLE
Fix #406: make integration tests test the locally built version

### DIFF
--- a/src/it/projects/effective-pom-artifact/pom.xml
+++ b/src/it/projects/effective-pom-artifact/pom.xml
@@ -27,4 +27,16 @@ under the License.
   <version>1.0-SNAPSHOT</version>
   <description>https://issues.apache.org/jira/browse/MPH-106</description>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <artifact>org.apache.maven.plugins:maven-help-plugin:@project.version@</artifact>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/it/projects/effective-pom-artifact/test.properties
+++ b/src/it/projects/effective-pom-artifact/test.properties
@@ -16,4 +16,3 @@
 # under the License.
 
 output = result.txt
-artifact = org.apache.maven.plugins:maven-help-plugin

--- a/src/it/projects/effective-pom-multimodule-artifact/pom.xml
+++ b/src/it/projects/effective-pom-multimodule-artifact/pom.xml
@@ -36,6 +36,14 @@ under the License.
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <artifact>org.apache.maven.plugins:maven-help-plugin:@project.version@</artifact>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/projects/effective-pom-multimodule-artifact/test.properties
+++ b/src/it/projects/effective-pom-multimodule-artifact/test.properties
@@ -16,4 +16,3 @@
 # under the License.
 
 output = result.txt
-artifact = org.apache.maven.plugins:maven-help-plugin

--- a/src/it/projects/evaluate-artifact-with-expression-with-output/pom.xml
+++ b/src/it/projects/evaluate-artifact-with-expression-with-output/pom.xml
@@ -41,6 +41,9 @@ under the License.
               <goal>evaluate</goal>
             </goals>
             <phase>package</phase>
+            <configuration>
+              <artifact>org.apache.maven.plugins:maven-help-plugin:@project.version@</artifact>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/it/projects/evaluate-artifact-with-expression-with-output/test.properties
+++ b/src/it/projects/evaluate-artifact-with-expression-with-output/test.properties
@@ -17,4 +17,3 @@
 
 expression = project.name
 output = result.txt
-artifact = org.apache.maven.plugins:maven-help-plugin


### PR DESCRIPTION
## Summary

Fixes apache/maven-help-plugin#406.

Three `effective-pom`/`evaluate` ITs were flaky on CI (while usually passing locally). Each ran its goal with `artifact=org.apache.maven.plugins:maven-help-plugin` (no version). The `artifact` parameter treats a missing version as `LATEST`, which the plugin resolves by fetching `maven-metadata.xml` and the plugin POM from remote repositories (Maven Central through the mock repository manager proxy).

This made the ITs depend on:

- network access to Maven Central at test time (transiently slow/unavailable on CI),
- whatever the "latest" released version is at that moment (a floating, non-hermetic input).

## Change

Pinned the artifact to the plugin version under test by configuring it in the ITs' (invoker-filtered) POMs:

```xml
<configuration>
  <artifact>org.apache.maven.plugins:maven-help-plugin:@project.version@</artifact>
</configuration>
```

`@project.version@` is filtered to the locally built version (e.g. `3.5.3-SNAPSHOT`), which the invoker `install` goal already places into the IT local repository. The fake project is therefore built from the local plugin POM: no `LATEST` metadata resolution, no Central downloads, and the output stays exactly what `verify.groovy` asserts. Removed the now-redundant `artifact` lines from the ITs' `test.properties`.

Applied to:
- `evaluate-artifact-with-expression-with-output` (MPH-114): the `artifact` parameter builds a fake project and evaluates expressions against it while `session.currentProject` remains the real project (per the enforcer rule).
- `effective-pom-artifact` (MPH-106): prints the effective POM of the given artifact.
- `effective-pom-multimodule-artifact` (MPH-105): same, in a multi-module reactor.

## Verification

- `mvn -Prun-its -Dinvoker.test=evaluate-artifact-with-expression-with-output verify`: passes.
- `mvn -Prun-its -Dinvoker.test=effective-pom-artifact,effective-pom-multimodule-artifact verify`: passes.
- Full `mvn -Prun-its verify`: BUILD SUCCESS, 33 ITs passed (2 skipped, unchanged), 26 unit tests pass.
- build.log shows `Skipped remote request for ...:3.5.3-SNAPSHOT/maven-metadata.xml locally installed metadata up-to-date`, i.e. no remote access.
