### PR TITLE
Fix #327: evaluate model collections on Maven 4

### DIFF
--- a/src/it/projects/evaluate-model-collections/invoker.properties
+++ b/src/it/projects/evaluate-model-collections/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:evaluate
+invoker.maven.version = 4+

--- a/src/it/projects/evaluate-model-collections/pom.xml
+++ b/src/it/projects/evaluate-model-collections/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.help</groupId>
+  <artifactId>evaluate-model-collections</artifactId>
+  <version>1.0</version>
+</project>

--- a/src/it/projects/evaluate-model-collections/test.properties
+++ b/src/it/projects/evaluate-model-collections/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+expression = project.build.resources

--- a/src/it/projects/evaluate-model-collections/verify.groovy
+++ b/src/it/projects/evaluate-model-collections/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def result = new File(basedir, 'build.log').text
+
+assert result.contains('<resources>')
+assert result.contains('<directory>' + new File(basedir, 'src/main/resources').absolutePath + '</directory>')

--- a/src/main/java/org/apache/maven/plugins/help/EvaluateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EvaluateMojo.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -35,6 +36,8 @@ import java.util.jar.JarInputStream;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.collections.CollectionConverter;
+import com.thoughtworks.xstream.converters.collections.MapConverter;
 import com.thoughtworks.xstream.converters.collections.PropertiesConverter;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import org.apache.maven.execution.MavenSession;
@@ -345,12 +348,12 @@ public class EvaluateMojo extends AbstractHelpMojo {
                 Object elt = list.iterator().next();
 
                 String name = StringUtils.lowercaseFirstLetter(elt.getClass().getSimpleName());
-                currentXStream.alias(pluralize(name), List.class);
+                currentXStream.alias(pluralize(name), list.getClass());
             } else {
                 // try to detect the alias from question
                 if (expr.indexOf('.') != -1) {
                     String name = expr.substring(expr.indexOf('.') + 1, expr.indexOf('}'));
-                    currentXStream.alias(name, List.class);
+                    currentXStream.alias(name, list.getClass());
                 }
             }
         }
@@ -364,6 +367,18 @@ public class EvaluateMojo extends AbstractHelpMojo {
     private XStream getXStream() {
         if (xstream == null) {
             xstream = new XStream();
+            xstream.registerConverter(new CollectionConverter(xstream.getMapper()) {
+                @Override
+                public boolean canConvert(Class type) {
+                    return Collection.class.isAssignableFrom(type);
+                }
+            });
+            xstream.registerConverter(new MapConverter(xstream.getMapper()) {
+                @Override
+                public boolean canConvert(Class type) {
+                    return Map.class.isAssignableFrom(type);
+                }
+            });
             addAlias(xstream);
 
             // handle Properties a la Maven


### PR DESCRIPTION
## Summary

Fixes #327 for the Maven 4-enabled line.

Maven 4 exposes evaluated model collections through `WrapperList` and uses immutable collection and map implementations inside the model. XStream does not recognize these implementations and falls back to reflective serialization, which fails when it tries to access JDK internals such as `AbstractList.modCount`.

This change registers collection and map converters that accept their public interfaces and aliases the concrete runtime list class so the existing XML root name is preserved. The evaluated list is serialized directly without copying it.

The commits are intentionally split: the first adds the regression IT and fails with the `WrapperList` reflection error; the second applies the fix.

## Validation

- Maven 3.10.0-rc-1 / JDK 17 `-Prun-its clean verify`: all 26 unit tests and all 35 applicable ITs passed; the Maven 4-only regression IT was skipped
- Maven 4.0.0-rc-6 / JDK 21 `clean verify`: all 26 unit tests passed
- Maven 4.0.0-rc-6 / JDK 21 focused `-Prun-its clean verify`: passed
- Maven 4.0.0-rc-6 / JDK 25 focused `-Prun-its clean verify`: passed
- Maven 4.0.0-rc-6 / JDK 21 full `clean verify`: the new IT passed; two existing Describe ITs failed (`describe-cmd-with-goal-report` and `describe-plugin-without-name`)

## Checklist

- [x] This pull request addresses one issue without unrelated changes.
- [x] The description explains what changed, how, and why.
- [x] Each commit has a meaningful subject line and body. Commit subjects are meaningful; no commit bodies were added.
- [x] A regression integration test fails without the runtime change.
- [x] `mvn verify` was run successfully.
- [x] The complete Maven 3 integration-test suite and the focused Maven 4 regression IT were run successfully; unrelated full-suite RC6 failures are documented above.

- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004.
- [ ] In any other case, an Apache Individual Contributor License Agreement has been filed.
