### PR TITLE
Fix #367 for Maven 3.x

### DIFF
--- a/src/main/java/org/apache/maven/plugins/help/DescribeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/DescribeMojo.java
@@ -27,7 +27,6 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -37,6 +36,8 @@ import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.Lifecycle;
 import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
 import org.apache.maven.lifecycle.mapping.LifecycleMapping;
+import org.apache.maven.lifecycle.mapping.LifecycleMojo;
+import org.apache.maven.lifecycle.mapping.LifecyclePhase;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.plugin.MavenPluginManager;
@@ -633,14 +634,16 @@ public class DescribeMojo extends AbstractHelpMojo {
                 throw new MojoExecutionException("The given phase '" + cmd + "' is an unknown phase.");
             }
 
-            Map<String, String> defaultLifecyclePhases = lifecycleMappings
-                    .get(project.getPackaging())
-                    .getLifecycles()
-                    .get("default")
-                    .getPhases();
             List<String> phases = lifecycle.getPhases();
 
-            if (lifecycle.getDefaultPhases() == null) {
+            if (lifecycle.getDefaultLifecyclePhases() == null
+                    || lifecycle.getDefaultLifecyclePhases().isEmpty()) {
+                Map<String, LifecyclePhase> defaultLifecyclePhases = lifecycleMappings
+                        .get(project.getPackaging())
+                        .getLifecycles()
+                        .get("default")
+                        .getLifecyclePhases();
+
                 descriptionBuffer.append("'").append(cmd);
                 descriptionBuffer
                         .append("' is a phase corresponding to this plugin:")
@@ -662,17 +665,13 @@ public class DescribeMojo extends AbstractHelpMojo {
                 descriptionBuffer.append(LS);
                 for (String key : phases) {
                     descriptionBuffer.append("* ").append(key).append(": ");
-                    String value = defaultLifecyclePhases.get(key);
-                    if (value != null && !value.isEmpty()) {
-                        for (StringTokenizer tok = new StringTokenizer(value, ","); tok.hasMoreTokens(); ) {
-                            descriptionBuffer.append(tok.nextToken().trim());
-
-                            if (!tok.hasMoreTokens()) {
-                                descriptionBuffer.append(LS);
-                            } else {
-                                descriptionBuffer.append(", ");
-                            }
-                        }
+                    LifecyclePhase phase = defaultLifecyclePhases.get(key);
+                    if (phase != null && !phase.getMojos().isEmpty()) {
+                        descriptionBuffer
+                                .append(phase.getMojos().stream()
+                                        .map(LifecycleMojo::getGoal)
+                                        .collect(Collectors.joining(", ")))
+                                .append(LS);
                     } else {
                         descriptionBuffer.append(NOT_DEFINED).append(LS);
                     }
@@ -685,9 +684,9 @@ public class DescribeMojo extends AbstractHelpMojo {
 
                 for (String key : phases) {
                     descriptionBuffer.append("* ").append(key).append(": ");
-                    if (lifecycle.getDefaultPhases().get(key) != null) {
+                    if (lifecycle.getDefaultLifecyclePhases().get(key) != null) {
                         descriptionBuffer
-                                .append(lifecycle.getDefaultPhases().get(key))
+                                .append(lifecycle.getDefaultLifecyclePhases().get(key))
                                 .append(LS);
                     } else {
                         descriptionBuffer.append(NOT_DEFINED).append(LS);

--- a/src/test/java/org/apache/maven/plugins/help/DescribeMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/help/DescribeMojoTest.java
@@ -21,10 +21,18 @@ package org.apache.maven.plugins.help;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.Lifecycle;
 import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
+import org.apache.maven.lifecycle.mapping.LifecycleMapping;
+import org.apache.maven.lifecycle.mapping.LifecyclePhase;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MavenPluginManager;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
@@ -351,6 +359,104 @@ public class DescribeMojoTest {
         } catch (Exception e) {
             fail(e.getMessage());
         }
+    }
+
+    /**
+     * Regression test for Maven 3.10, where the default lifecycle has an empty map of built-in bindings. The mojo must
+     * use the packaging-specific lifecycle mapping in that case.
+     */
+    @Test
+    public void testDescribeCommandPackagingSpecificPhaseShowsBindings() throws Exception {
+        Lifecycle lifecycle = mock(Lifecycle.class);
+        when(lifecycle.getId()).thenReturn("default");
+        when(lifecycle.getPhases()).thenReturn(Arrays.asList("validate", "compile", "test", "package"));
+        when(lifecycle.getDefaultPhases()).thenReturn(Collections.emptyMap());
+        when(lifecycle.getDefaultLifecyclePhases()).thenReturn(Collections.emptyMap());
+
+        Map<String, Lifecycle> phaseMap = new HashMap<>();
+        for (String phase : Arrays.asList("validate", "compile", "test", "package")) {
+            phaseMap.put(phase, lifecycle);
+        }
+        DefaultLifecycles defaultLifecycles = mock(DefaultLifecycles.class);
+        when(defaultLifecycles.getPhaseToLifecycleMap()).thenReturn(phaseMap);
+
+        Map<String, String> legacyPhases = new LinkedHashMap<>();
+        legacyPhases.put("compile", "org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile");
+        Map<String, LifecyclePhase> lifecyclePhases = new LinkedHashMap<>();
+        lifecyclePhases.put(
+                "compile", new LifecyclePhase("org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile"));
+
+        org.apache.maven.lifecycle.mapping.Lifecycle mappingLifecycle =
+                mock(org.apache.maven.lifecycle.mapping.Lifecycle.class);
+        when(mappingLifecycle.getPhases()).thenReturn(legacyPhases);
+        when(mappingLifecycle.getLifecyclePhases()).thenReturn(lifecyclePhases);
+        LifecycleMapping lifecycleMapping = mock(LifecycleMapping.class);
+        when(lifecycleMapping.getLifecycles()).thenReturn(Collections.singletonMap("default", mappingLifecycle));
+
+        MavenProject project = mock(MavenProject.class);
+        when(project.getPackaging()).thenReturn("jar");
+
+        DescribeMojo mojo = new DescribeMojo();
+        setFieldWithReflection(mojo, "cmd", "compile");
+        setFieldWithReflection(mojo, "defaultLifecycles", defaultLifecycles);
+        setFieldWithReflection(mojo, "lifecycleMappings", Collections.singletonMap("jar", lifecycleMapping));
+        setParentFieldWithReflection(mojo, "project", project);
+
+        StringBuilder buffer = new StringBuilder();
+        Method describeCommand = DescribeMojo.class.getDeclaredMethod("describeCommand", StringBuilder.class);
+        describeCommand.setAccessible(true);
+        boolean result = (boolean) describeCommand.invoke(mojo, buffer);
+
+        String output = buffer.toString();
+        assertFalse(result);
+        assertTrue("Should show the compiler plugin: " + output, output.contains("maven-compiler-plugin"));
+        assertFalse("compile should not be 'Not defined': " + output, output.contains("* compile: Not defined"));
+        assertTrue("validate has no binding: " + output, output.contains("* validate: Not defined"));
+        assertTrue(output, output.contains("It is a part of the lifecycle for the POM packaging 'jar'"));
+    }
+
+    @Test
+    public void testDescribeCommandBuiltinLifecyclePhaseShowsBindings() throws Exception {
+        Map<String, String> legacyPhases = new LinkedHashMap<>();
+        legacyPhases.put("clean", "org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean");
+        Map<String, LifecyclePhase> lifecyclePhases = new LinkedHashMap<>();
+        lifecyclePhases.put("pre-clean", null);
+        lifecyclePhases.put("clean", new LifecyclePhase("org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean"));
+        lifecyclePhases.put("post-clean", null);
+
+        Lifecycle lifecycle = mock(Lifecycle.class);
+        when(lifecycle.getId()).thenReturn("clean");
+        when(lifecycle.getPhases()).thenReturn(Arrays.asList("pre-clean", "clean", "post-clean"));
+        when(lifecycle.getDefaultPhases()).thenReturn(legacyPhases);
+        when(lifecycle.getDefaultLifecyclePhases()).thenReturn(lifecyclePhases);
+
+        Map<String, Lifecycle> phaseMap = new HashMap<>();
+        for (String phase : Arrays.asList("pre-clean", "clean", "post-clean")) {
+            phaseMap.put(phase, lifecycle);
+        }
+        DefaultLifecycles defaultLifecycles = mock(DefaultLifecycles.class);
+        when(defaultLifecycles.getPhaseToLifecycleMap()).thenReturn(phaseMap);
+
+        MavenProject project = mock(MavenProject.class);
+        when(project.getPackaging()).thenReturn("jar");
+
+        DescribeMojo mojo = new DescribeMojo();
+        setFieldWithReflection(mojo, "cmd", "clean");
+        setFieldWithReflection(mojo, "defaultLifecycles", defaultLifecycles);
+        setFieldWithReflection(mojo, "lifecycleMappings", Collections.emptyMap());
+        setParentFieldWithReflection(mojo, "project", project);
+
+        StringBuilder buffer = new StringBuilder();
+        Method describeCommand = DescribeMojo.class.getDeclaredMethod("describeCommand", StringBuilder.class);
+        describeCommand.setAccessible(true);
+        boolean result = (boolean) describeCommand.invoke(mojo, buffer);
+
+        String output = buffer.toString();
+        assertFalse(result);
+        assertTrue(output, output.contains("'clean' is a phase within the 'clean' lifecycle"));
+        assertTrue(output, output.contains("maven-clean-plugin"));
+        assertTrue(output, output.contains("* pre-clean: Not defined"));
+        assertTrue(output, output.contains("* post-clean: Not defined"));
     }
 
     private static void setParentFieldWithReflection(

--- a/src/test/java/org/apache/maven/plugins/help/DescribeMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/help/DescribeMojoTest.java
@@ -370,7 +370,6 @@ public class DescribeMojoTest {
         Lifecycle lifecycle = mock(Lifecycle.class);
         when(lifecycle.getId()).thenReturn("default");
         when(lifecycle.getPhases()).thenReturn(Arrays.asList("validate", "compile", "test", "package"));
-        when(lifecycle.getDefaultPhases()).thenReturn(Collections.emptyMap());
         when(lifecycle.getDefaultLifecyclePhases()).thenReturn(Collections.emptyMap());
 
         Map<String, Lifecycle> phaseMap = new HashMap<>();
@@ -380,15 +379,12 @@ public class DescribeMojoTest {
         DefaultLifecycles defaultLifecycles = mock(DefaultLifecycles.class);
         when(defaultLifecycles.getPhaseToLifecycleMap()).thenReturn(phaseMap);
 
-        Map<String, String> legacyPhases = new LinkedHashMap<>();
-        legacyPhases.put("compile", "org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile");
         Map<String, LifecyclePhase> lifecyclePhases = new LinkedHashMap<>();
         lifecyclePhases.put(
                 "compile", new LifecyclePhase("org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile"));
 
         org.apache.maven.lifecycle.mapping.Lifecycle mappingLifecycle =
                 mock(org.apache.maven.lifecycle.mapping.Lifecycle.class);
-        when(mappingLifecycle.getPhases()).thenReturn(legacyPhases);
         when(mappingLifecycle.getLifecyclePhases()).thenReturn(lifecyclePhases);
         LifecycleMapping lifecycleMapping = mock(LifecycleMapping.class);
         when(lifecycleMapping.getLifecycles()).thenReturn(Collections.singletonMap("default", mappingLifecycle));
@@ -417,8 +413,6 @@ public class DescribeMojoTest {
 
     @Test
     public void testDescribeCommandBuiltinLifecyclePhaseShowsBindings() throws Exception {
-        Map<String, String> legacyPhases = new LinkedHashMap<>();
-        legacyPhases.put("clean", "org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean");
         Map<String, LifecyclePhase> lifecyclePhases = new LinkedHashMap<>();
         lifecyclePhases.put("pre-clean", null);
         lifecyclePhases.put("clean", new LifecyclePhase("org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean"));
@@ -427,7 +421,6 @@ public class DescribeMojoTest {
         Lifecycle lifecycle = mock(Lifecycle.class);
         when(lifecycle.getId()).thenReturn("clean");
         when(lifecycle.getPhases()).thenReturn(Arrays.asList("pre-clean", "clean", "post-clean"));
-        when(lifecycle.getDefaultPhases()).thenReturn(legacyPhases);
         when(lifecycle.getDefaultLifecyclePhases()).thenReturn(lifecyclePhases);
 
         Map<String, Lifecycle> phaseMap = new HashMap<>();


### PR DESCRIPTION
## Summary

Fixes #367 for 3.x branch.

This backports the lifecycle-mapping part of #372 to the `maven-help-plugin-3.4.x` maintenance branch. Maven 3.10 represents the default lifecycle's built-in bindings as an empty map. The 3.x implementation only fell back to the packaging-specific mapping when that map was `null`, so `help:describe -Dcmd=deploy` reported every phase as `Not defined` and the existing `describe-cmd` integration test failed in [this Actions job](https://github.com/apache/maven-help-plugin/actions/runs/31315017957/job/93589464831).

The change treats both null and empty built-in mappings as packaging-specific and replaces the deprecated string lifecycle APIs with their typed equivalents. Those APIs were verified against Maven 3.6.3, the minimum version declared by this branch.

The commits are intentionally split: the first adds a unit regression that fails without the runtime change, and the second applies the fix. The existing `describe-cmd` IT provides end-to-end coverage of the reported failure.

## Validation

- Maven 3.6.3 / JDK 8: `mvn clean verify -P run-its` — 24 unit tests and all 34 ITs passed
- Maven 3.9.16 / JDK 21: `mvn clean verify -P run-its` — 24 unit tests and all 34 ITs passed
- Maven 3.10.0-rc-1 / JDK 17: `mvn clean verify -P run-its` — 24 unit tests and all 34 ITs passed, including `describe-cmd`

## Checklist

- [x] This pull request addresses one issue without unrelated changes.
- [x] The description explains what changed, how, and why.
- [x] Each commit has a meaningful subject line and body.
- [x] A regression unit test fails without the runtime change.
- [x] `mvn verify` was run successfully.
- [x] The integration tests were run successfully with `mvn -Prun-its verify`.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [ ] In any other case, an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) has been filed.
