### PR TITLE
Do not let effective-pom encoding fall back to null

### DIFF
--- a/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -107,7 +108,8 @@ public class EffectivePomMojo extends AbstractEffectiveMojo {
         }
 
         StringWriter w = new StringWriter();
-        String encoding = output != null ? project.getModel().getModelEncoding() : System.getProperty("file.encoding");
+        String encoding = encodingOrDefault(
+                output != null ? project.getModel().getModelEncoding() : System.getProperty("file.encoding"));
         XMLWriter writer = new PrettyPrintXMLWriter(
                 w, StringUtils.repeat(" ", XmlWriterUtil.DEFAULT_INDENTATION_SIZE), encoding, null);
 
@@ -211,6 +213,13 @@ public class EffectivePomMojo extends AbstractEffectiveMojo {
         Properties properties = new SortedProperties();
         properties.putAll(pom.getProperties());
         pom.setProperties(properties);
+    }
+
+    static String encodingOrDefault(String encoding) {
+        if (encoding == null || encoding.isEmpty()) {
+            return Charset.defaultCharset().name();
+        }
+        return encoding;
     }
 
     private static class InputLocationStringFormatter extends InputLocation.StringFormatter {

--- a/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
@@ -107,7 +107,13 @@ public class EffectivePomMojo extends AbstractEffectiveMojo {
         }
 
         StringWriter w = new StringWriter();
-        String encoding = output != null ? project.getModel().getModelEncoding() : System.getProperty("file.encoding");
+        String rawEncoding;
+        if (output != null) {
+            rawEncoding = project.getModel().getModelEncoding();
+        } else {
+            rawEncoding = System.getProperty("file.encoding");
+        }
+        String encoding = encodingOrDefault(rawEncoding);
         XMLWriter writer = new PrettyPrintXMLWriter(
                 w, StringUtils.repeat(" ", XmlWriterUtil.DEFAULT_INDENTATION_SIZE), encoding, null);
 
@@ -211,6 +217,13 @@ public class EffectivePomMojo extends AbstractEffectiveMojo {
         Properties properties = new SortedProperties();
         properties.putAll(pom.getProperties());
         pom.setProperties(properties);
+    }
+
+    static String encodingOrDefault(String encoding) {
+        if (encoding == null || encoding.isEmpty()) {
+            return "UTF-8";
+        }
+        return encoding;
     }
 
     private static class InputLocationStringFormatter extends InputLocation.StringFormatter {

--- a/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
@@ -107,12 +107,7 @@ public class EffectivePomMojo extends AbstractEffectiveMojo {
         }
 
         StringWriter w = new StringWriter();
-        String rawEncoding;
-        if (output != null) {
-            rawEncoding = project.getModel().getModelEncoding();
-        } else {
-            rawEncoding = System.getProperty("file.encoding");
-        }
+        String rawEncoding = output != null ? project.getModel().getModelEncoding() : "UTF-8";
         String encoding = encodingOrDefault(rawEncoding);
         XMLWriter writer = new PrettyPrintXMLWriter(
                 w, StringUtils.repeat(" ", XmlWriterUtil.DEFAULT_INDENTATION_SIZE), encoding, null);

--- a/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EffectivePomMojo.java
@@ -107,8 +107,7 @@ public class EffectivePomMojo extends AbstractEffectiveMojo {
         }
 
         StringWriter w = new StringWriter();
-        String rawEncoding = output != null ? project.getModel().getModelEncoding() : "UTF-8";
-        String encoding = encodingOrDefault(rawEncoding);
+        String encoding = encodingOrDefault(project.getModel().getModelEncoding());
         XMLWriter writer = new PrettyPrintXMLWriter(
                 w, StringUtils.repeat(" ", XmlWriterUtil.DEFAULT_INDENTATION_SIZE), encoding, null);
 

--- a/src/test/java/org/apache/maven/plugins/help/EffectivePomMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/help/EffectivePomMojoTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.help;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EffectivePomMojoTest {
+
+    @Test
+    void encodingOrDefaultFallsBackToUtf8() {
+        assertEquals("UTF-8", EffectivePomMojo.encodingOrDefault(null));
+        assertEquals("UTF-8", EffectivePomMojo.encodingOrDefault(""));
+    }
+
+    @Test
+    void encodingOrDefaultKeepsExplicitValue() {
+        assertEquals("UTF-8", EffectivePomMojo.encodingOrDefault("UTF-8"));
+        assertEquals("ISO-8859-1", EffectivePomMojo.encodingOrDefault("ISO-8859-1"));
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/help/EffectivePomMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/help/EffectivePomMojoTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.help;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class EffectivePomMojoTest {
+
+    @Test
+    void encodingFallbackNeverNull() {
+        String fromNull = EffectivePomMojo.encodingOrDefault(null);
+        assertNotNull(fromNull);
+        assertFalse(fromNull.isEmpty());
+
+        String fromBlank = EffectivePomMojo.encodingOrDefault("");
+        assertNotNull(fromBlank);
+        assertFalse(fromBlank.isEmpty());
+
+        assertEquals("UTF-8", EffectivePomMojo.encodingOrDefault("UTF-8"));
+    }
+}


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

`file.encoding` and `Model.getModelEncoding()` can both be missing. The XML writer then gets a null encoding. I fall back to `Charset.defaultCharset()` and added a unit test that fails if that helper returns null.

Fixes #394
