### PR TITLE
Fix #393: stop reading LATEST from the deprecated Artifact constant

### DIFF
--- a/src/main/java/org/apache/maven/plugins/help/AbstractHelpMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/AbstractHelpMojo.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.plugin.AbstractMojo;
@@ -48,6 +47,14 @@ import org.eclipse.aether.resolution.ArtifactRequest;
  * @since 2.1
  */
 public abstract class AbstractHelpMojo extends AbstractMojo {
+
+    /**
+     * The metaversion Aether resolves to the newest available version, used when the caller gives
+     * coordinates without one. Spelled out here rather than read from
+     * {@code org.apache.maven.artifact.Artifact#LATEST_VERSION}, which Maven 4 deprecates.
+     */
+    private static final String LATEST_VERSION = "LATEST";
+
     /** The maximum length of a display line. */
     protected static final int LINE_LENGTH = 79;
 
@@ -144,7 +151,7 @@ public abstract class AbstractHelpMojo extends AbstractMojo {
             case 2:
                 groupId = artifactParts[0];
                 artifactId = artifactParts[1];
-                version = Artifact.LATEST_VERSION;
+                version = LATEST_VERSION;
                 break;
             case 3:
                 groupId = artifactParts[0];

--- a/src/main/java/org/apache/maven/plugins/help/AbstractHelpMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/AbstractHelpMojo.java
@@ -48,13 +48,6 @@ import org.eclipse.aether.resolution.ArtifactRequest;
  */
 public abstract class AbstractHelpMojo extends AbstractMojo {
 
-    /**
-     * The metaversion Aether resolves to the newest available version, used when the caller gives
-     * coordinates without one. Spelled out here rather than read from
-     * {@code org.apache.maven.artifact.Artifact#LATEST_VERSION}, which Maven 4 deprecates.
-     */
-    private static final String LATEST_VERSION = "LATEST";
-
     /** The maximum length of a display line. */
     protected static final int LINE_LENGTH = 79;
 
@@ -151,7 +144,8 @@ public abstract class AbstractHelpMojo extends AbstractMojo {
             case 2:
                 groupId = artifactParts[0];
                 artifactId = artifactParts[1];
-                version = LATEST_VERSION;
+                // Not null: Aether normalises a null version to "", not to a metaversion.
+                version = "LATEST";
                 break;
             case 3:
                 groupId = artifactParts[0];

--- a/src/test/java/org/apache/maven/plugins/help/AbstractHelpMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/help/AbstractHelpMojoTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.help;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.eclipse.aether.artifact.Artifact;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests the coordinate parsing in {@link AbstractHelpMojo#getAetherArtifact(String, String)}.
+ */
+class AbstractHelpMojoTest {
+
+    private final AbstractHelpMojo mojo = new AbstractHelpMojo(null, null) {
+        @Override
+        public void execute() {}
+    };
+
+    @Test
+    void coordinatesWithoutAVersionGetTheLatestMetaversion() throws Exception {
+        Artifact artifact = mojo.getAetherArtifact("org.apache.maven:maven-core", "pom");
+
+        assertEquals("org.apache.maven", artifact.getGroupId());
+        assertEquals("maven-core", artifact.getArtifactId());
+        assertEquals("pom", artifact.getExtension());
+        // The literal, not the constant: leaving the version out has to keep producing a
+        // metaversion the resolver recognises. A null version would arrive here as "" instead.
+        assertEquals("LATEST", artifact.getVersion());
+    }
+
+    @Test
+    void coordinatesWithAVersionKeepIt() throws Exception {
+        Artifact artifact = mojo.getAetherArtifact("org.apache.maven:maven-core:3.9.16", "pom");
+
+        assertEquals("3.9.16", artifact.getVersion());
+    }
+
+    @Test
+    void coordinatesWithTooManyPartsAreRejected() {
+        assertThrows(
+                MojoExecutionException.class,
+                () -> mojo.getAetherArtifact("org.apache.maven:maven-core:3.9.16:extra", "pom"));
+    }
+
+    @Test
+    void emptyCoordinatesAreRejected() {
+        assertThrows(IllegalArgumentException.class, () -> mojo.getAetherArtifact("", "pom"));
+    }
+}


### PR DESCRIPTION
Fixes #393.

`getAetherArtifact()` filled in a missing version from `org.apache.maven.artifact.Artifact.LATEST_VERSION`, which Maven 4 deprecates. That import was the only use of the class, so it goes too. The value stays `"LATEST"`, now a private constant on the mojo.

One thing on the issue's suggested replacement: null does not work here. Aether normalises it to the empty string, not to a metaversion.

```java
new DefaultArtifact("g", "a", "jar", (String) null).getVersion()   // ""
new DefaultArtifact("g", "a", "jar", "LATEST").getVersion()        // "LATEST"
```

(checked against maven-resolver-api 2.0.21). The result goes straight into `readArtifactDescriptor` and `resolveArtifact`, so an empty version would make `help:effective-pom -Dartifact=groupId:artifactId` look for `g:a:pom:` instead of the newest release.

`getAetherArtifact` had no tests, so this adds four covering the two-part and three-part forms and the two rejection paths. The metaversion assertion uses the literal rather than the constant, so it still fails if the value changes. `mvn test` is 30 passing, spotless clean.


---

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
