### PR TITLE
[MPH-210] Fix help:evaluate for Maven 3 model collections

### DIFF
--- a/src/it/projects/evaluate-model-collections/invoker.properties
+++ b/src/it/projects/evaluate-model-collections/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:evaluate
+invoker.maven.version = 4-

--- a/src/it/projects/evaluate-model-collections/pom.xml
+++ b/src/it/projects/evaluate-model-collections/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.help</groupId>
+  <artifactId>evaluate-model-collections</artifactId>
+  <version>1.0</version>
+</project>

--- a/src/it/projects/evaluate-model-collections/test.properties
+++ b/src/it/projects/evaluate-model-collections/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+expression = project.build.resources

--- a/src/it/projects/evaluate-model-collections/verify.groovy
+++ b/src/it/projects/evaluate-model-collections/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def result = new File(basedir, 'build.log').text
+
+assert result.contains('<resources>')
+assert result.contains('<directory>' + new File(basedir, 'src/main/resources').absolutePath + '</directory>')

--- a/src/main/java/org/apache/maven/plugins/help/EvaluateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/help/EvaluateMojo.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -35,6 +36,7 @@ import java.util.jar.JarInputStream;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.collections.CollectionConverter;
 import com.thoughtworks.xstream.converters.collections.PropertiesConverter;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import org.apache.maven.execution.MavenSession;
@@ -345,12 +347,12 @@ public class EvaluateMojo extends AbstractHelpMojo {
                 Object elt = list.iterator().next();
 
                 String name = StringUtils.lowercaseFirstLetter(elt.getClass().getSimpleName());
-                currentXStream.alias(pluralize(name), List.class);
+                currentXStream.alias(pluralize(name), list.getClass());
             } else {
                 // try to detect the alias from question
                 if (expr.indexOf('.') != -1) {
                     String name = expr.substring(expr.indexOf('.') + 1, expr.indexOf('}'));
-                    currentXStream.alias(name, List.class);
+                    currentXStream.alias(name, list.getClass());
                 }
             }
         }
@@ -364,6 +366,12 @@ public class EvaluateMojo extends AbstractHelpMojo {
     private XStream getXStream() {
         if (xstream == null) {
             xstream = new XStream();
+            xstream.registerConverter(new CollectionConverter(xstream.getMapper()) {
+                @Override
+                public boolean canConvert(Class type) {
+                    return Collection.class.isAssignableFrom(type);
+                }
+            });
             addAlias(xstream);
 
             // handle Properties a la Maven


### PR DESCRIPTION
## Summary

Fixes #327.

`help:evaluate` can receive model collections implemented by Maven 3's internal
`ModelMerger.MergingList`. XStream does not recognize that implementation as a
collection and falls back to reflective serialization. On recent JDKs, this
fails when it tries to access `AbstractList.modCount`.

This change registers a collection converter that accepts every `Collection`
implementation and aliases the concrete runtime list class so the existing XML
root name is preserved. The evaluated list is serialized directly without
copying it.

This PR targets `master`, the current 3.5.x line. The plugin still declares
Maven 3.6.3 as its runtime prerequisite. The regression IT is limited to Maven
3 because Maven 4 exposes different model collection implementations.

This replaces #416, which targeted the 3.4.x maintenance branch currently under
retirement review. PR #417 covers Maven 4-specific collection and map
implementations and can build on this Maven 3 change. The commits remain
intentionally split: the first adds the regression IT and the second applies
the fix.

## Validation

- Maven 3.9.16 / JDK 21: `mvn -Prun-its clean verify` - 30 unit tests and all
  36 integration tests passed.
- Maven 3.10.0-rc-1 / JDK 21: `mvn -Prun-its clean verify` - 30 unit tests and
  all 36 integration tests passed.
- Maven 4.0.0-rc-6 / JDK 21: the unit-test phase passed all 30 tests. The full
  Invoker run passed 32 tests, skipped 2 Maven-version-specific tests, and hit
  the two existing unrelated failures also documented by #417:
  `describe-cmd-with-goal-report` and `describe-plugin-without-name`.
- `mvn spotless:apply` made no changes.
- The failure was reproduced before the fix with Help Plugin 3.5.2, Maven
  3.9.16, and JDK 21.

## Checklist

- [x] A JIRA issue exists for this change: MPH-210.
- [x] This pull request addresses only that issue.
- [x] Each commit has a meaningful subject line and body.
- [x] The pull request title follows the `[MPH-XXX]` convention.
- [x] This description explains what changed, how, and why.
- [x] `mvn clean verify` passed.
- [x] The integration tests passed with Maven 3.9.16 and Maven 3.10.0-rc-1.
- [x] I hereby declare this contribution to be licenced under the
  [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [ ] In any other case, an Apache Individual Contributor License Agreement has
  been filed.
